### PR TITLE
Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ then please let us know so that we can add your server to the list of endpoints,
 which are maintained inside the `ENDPOINTS` file.
 
 ## Future work
-* Introduce alias resolution to match nodes on both the forward and reverse path
+* Allow the client to (optionally) request a traceroute to another address
 
 ## Disclaimer
 Both the client and the server are subject to change, as they are still early in development.

--- a/client/src/args.py
+++ b/client/src/args.py
@@ -77,10 +77,12 @@ def parse_arguments() -> argparse.Namespace:
         help="Do not perform a reverse DNS lookup on the IP addresses.",
     )
     parser.add_argument(
-        "--no-merge",
-        action="store_true",
-        help="Do not merge the vertices before printing the graph.",
-    ),
+        "-m",
+        "--merge",
+        choices=("none", "address", "router"),
+        default="address",
+        help="Choose how to merge the vertices.",
+    )
     parser.add_argument(
         "-o",
         "--output",
@@ -120,7 +122,8 @@ def parse_arguments() -> argparse.Namespace:
 
     algo_parsers = parser.add_subparsers(dest="engine", required=True)
     multipath_parser = algo_parsers.add_parser(
-        "multipath", help="Detect multiple paths."
+        "multipath",
+        help="Detect multiple paths.",
     )
     multipath_parser.add_argument(
         "--retry",
@@ -152,7 +155,8 @@ def parse_arguments() -> argparse.Namespace:
         help="The maximum burst size to send to a hop.",
     )
     singlepath_parser = algo_parsers.add_parser(
-        "singlepath", help="Illuminate a single path."
+        "singlepath",
+        help="Illuminate a single path.",
     )
     singlepath_parser.add_argument(
         "--flow",

--- a/client/src/args.py
+++ b/client/src/args.py
@@ -77,11 +77,14 @@ def parse_arguments() -> argparse.Namespace:
         help="Do not perform a reverse DNS lookup on the IP addresses.",
     )
     parser.add_argument(
-        "-m",
-        "--merge",
-        choices=("none", "address", "router"),
-        default="address",
-        help="Choose how to merge the vertices.",
+        "--no-merge",
+        action="store_true",
+        help="Do not merge the vertices before printing the graph.",
+    ),
+    parser.add_argument(
+        "--resolve-aliases",
+        action="store_true",
+        help="Resolve router level aliases.",
     )
     parser.add_argument(
         "-o",
@@ -122,8 +125,7 @@ def parse_arguments() -> argparse.Namespace:
 
     algo_parsers = parser.add_subparsers(dest="engine", required=True)
     multipath_parser = algo_parsers.add_parser(
-        "multipath",
-        help="Detect multiple paths.",
+        "multipath", help="Detect multiple paths."
     )
     multipath_parser.add_argument(
         "--retry",
@@ -155,8 +157,7 @@ def parse_arguments() -> argparse.Namespace:
         help="The maximum burst size to send to a hop.",
     )
     singlepath_parser = algo_parsers.add_parser(
-        "singlepath",
-        help="Illuminate a single path.",
+        "singlepath", help="Illuminate a single path."
     )
     singlepath_parser.add_argument(
         "--flow",

--- a/client/src/client.py
+++ b/client/src/client.py
@@ -261,10 +261,7 @@ def main():
         traces["reverse"] = root
 
     if args.direction == "two-way":
-        try:
-            apar(traces["forward"], traces["reverse"])
-        except:
-            pass
+        apar(traces["forward"], traces["reverse"])
 
     hostnames = {}
     if not args.no_resolve:

--- a/client/src/client.py
+++ b/client/src/client.py
@@ -35,6 +35,8 @@ from .graph import create_graph
 from .args import parse_arguments
 from .transmit import transmit_measurement
 
+from .core.merge import Apar
+
 
 logging.getLogger("graphviz").setLevel(logging.ERROR)
 
@@ -257,6 +259,13 @@ def main():
 
         root = discover(engine, probe_gen, target, args.min_ttl, args.max_ttl)
         traces["reverse"] = root
+
+    if args.direction == "two-way":
+        try:
+            apar = Apar(traces["forward"], traces["reverse"])
+            apar.run()
+        except:
+            pass
 
     hostnames = {}
     if not args.no_resolve:

--- a/client/src/client.py
+++ b/client/src/client.py
@@ -35,7 +35,7 @@ from .graph import create_graph
 from .args import parse_arguments
 from .transmit import transmit_measurement
 
-from .core.merge import Apar
+from .core.merge import apar
 
 
 logging.getLogger("graphviz").setLevel(logging.ERROR)
@@ -262,8 +262,7 @@ def main():
 
     if args.direction == "two-way":
         try:
-            apar = Apar(traces["forward"], traces["reverse"])
-            apar.run()
+            apar(traces["forward"], traces["reverse"])
         except:
             pass
 

--- a/client/src/core/apar.py
+++ b/client/src/core/apar.py
@@ -46,7 +46,7 @@ def form_subnets(forward, reverse):
         for subnet, vertices in matches.items():
             if completeness(subnet, vertices) < 0.5:
                 continue
-            for trace in chain(forward.traces(), reverse.traces()):
+            for trace in chain(forward.paths(), reverse.paths()):
                 shared_vertices = set(trace) & vertices
                 if not accuracy(shared_vertices, trace):
                     break
@@ -62,7 +62,7 @@ def form_subnets(forward, reverse):
 
 
 def no_loop(forward, reverse, aliases):
-    for trace in map(set, chain(forward.traces(), reverse.traces())):
+    for trace in map(set, chain(forward.paths(), reverse.paths())):
         if len(trace & aliases) > 1:
             return False
     return True
@@ -108,8 +108,8 @@ def resolved_alias(f_trace, r_trace, f_index, r_index, aliases):
 
 
 def resolve_aliases(forward, reverse, p2p, aliases=[]):
-    forward_traces = list(forward.traces())
-    reverse_traces = list(reverse.traces())
+    forward_traces = list(forward.paths())
+    reverse_traces = list(reverse.paths())
 
     aliases = list(aliases)
     seen_subnets = {}
@@ -155,13 +155,11 @@ def apar(forward, reverse):
     aliases = resolve_aliases(forward, reverse, False)
     aliases = resolve_aliases(forward, reverse, True, aliases)
 
-    """
     with open("traces.txt", "w") as f:
         lines = []
-        for trace in chain(forward.traces(), reverse.traces()):
+        for trace in chain(forward.paths(), reverse.paths()):
             lines += ["#"] + [ v.address for v in trace ]
         f.writelines("\n".join(lines))
-    """
 
     log.info(f"{aliases=}")
     return aliases

--- a/client/src/core/apar.py
+++ b/client/src/core/apar.py
@@ -155,11 +155,14 @@ def apar(forward, reverse):
     aliases = resolve_aliases(forward, reverse, False)
     aliases = resolve_aliases(forward, reverse, True, aliases)
 
+    # Uncomment below lines for a comparison with KAPAR
+    """
     with open("traces.txt", "w") as f:
         lines = []
         for trace in chain(forward.paths(), reverse.paths()):
             lines += ["#"] + [ v.address for v in trace ]
         f.writelines("\n".join(lines))
+    """
 
     log.info(f"{aliases=}")
     return aliases

--- a/client/src/core/container.py
+++ b/client/src/core/container.py
@@ -116,6 +116,22 @@ class TracerouteVertex:
 
         yield from _flatten(self)
 
+    def traces(self) -> Generator[list["TracerouteVertex"], None, None]:
+        "Return all loop-free paths from start to finish."
+        def _traces(vertex, trace=[]):
+            trace = list(trace)
+            if vertex in trace:
+                return
+
+            trace.append(vertex)
+            if not vertex.successors:
+                yield trace
+            for next_vertex in vertex.successors:
+                yield from _traces(next_vertex, trace)    
+
+        yield from _traces(self)
+
+
     def merge(self, other: "TracerouteVertex") -> "TracerouteVertex":
         assert self == other
         log.debug(f"Merging {self} with {other}")

--- a/client/src/core/engine.py
+++ b/client/src/core/engine.py
@@ -236,7 +236,7 @@ class MultipathEngine(AbstractEngine):
     def __nprobes(self, hop: TracerouteHop) -> int:
         """Computes the number of flows needed for the next hop."""
         probes = lambda v: stopping_point(
-            max(1, len(v.successors)) + 1, self.confidence
+            max(1, len(v.successors)), self.confidence
         )
 
         total_flows = len(hop.flows)

--- a/client/src/core/engine.py
+++ b/client/src/core/engine.py
@@ -41,7 +41,6 @@ class AbstractEngine:
         inter: float,
         timeout: float,
         abort: int,
-        opt_single_vertex_hop: bool = False,
     ):
         assert inter >= 0
         self.inter = inter
@@ -49,17 +48,6 @@ class AbstractEngine:
         self.timeout = timeout
         assert abort >= 2
         self.abort = abort
-        self.opt_single_vertex_hop = opt_single_vertex_hop
-
-    def _generate_flows(self, hop: TracerouteHop) -> Generator[set[int], None, None]:
-        """Generates flow sets for probing. Called by _probe_and_update."""
-        raise NotImplementedError
-
-    def _send_probes_to_hop(
-        self, probe_generator: AbstractProbeGen, hop: TracerouteHop, flows: set[int]
-    ):
-        """Sends probes with a set of flows to the specified hop."""
-        raise NotImplementedError
 
     def _probe_and_update(
         self,
@@ -67,41 +55,7 @@ class AbstractEngine:
         hop: TracerouteHop,
         next_hop: TracerouteHop,
     ):
-        """Probes a pair of hops and connects their vertices to each other."""
-        for flows in self._generate_flows(hop):
-
-            # Send probes to the next hop first.
-            # For the path A -> B -> C -> D this leads to the following probing pattern:
-            # "B -> A -> C -> B -> D -> C" instead of
-            # "A -> B -> B -> C -> C -> D".
-            # By avoiding to probe hops twice in a row the impact of rate limiting
-            # is reduced.
-            n_hops = len(next_hop)
-            self._send_probes_to_hop(probe_generator, next_hop, flows)
-            if len(next_hop) == n_hops:
-                log.warning("No new vertices detected, breaking from send loop")
-                break
-
-            missing_flows = next_hop.flows - hop.flows
-            send_probes = lambda: self._send_probes_to_hop(
-                probe_generator, hop, missing_flows
-            )
-
-            if missing_flows:
-                if len(hop) == 1:
-                    if hop.ttl == 0:
-                        log.debug("Root hop found -> Skipping send_probes")
-                        hop.first().flow_set.update(missing_flows)
-                    elif self.opt_single_vertex_hop:
-                        log.debug("Single vertex hop found -> Skipping send_probes")
-                        hop.first().shadow_flow_set.update(missing_flows)
-                    else:
-                        send_probes()
-                        hop.first().shadow_flow_set.update(missing_flows - hop.flows)
-                else:
-                    send_probes()
-
-            hop.connectTo(next_hop)
+        raise NotImplementedError
 
     def discover(
         self,
@@ -188,15 +142,14 @@ class SinglepathEngine(AbstractEngine):
         assert flow > 0
         self.flow = flow
 
-    def _generate_flows(self, hop: TracerouteHop) -> Generator[set[int], None, None]:
-        """Generates a single flow set."""
-        yield {self.flow}
-
-    def _send_probes_to_hop(
-        self, probe_generator: AbstractProbeGen, hop: TracerouteHop, flows: set[int]
+    def _probe_and_update(
+        self,
+        probe_generator: AbstractProbeGen,
+        hop: TracerouteHop,
+        next_hop: TracerouteHop,
     ):
         probes = [
-            probe_generator.create_probe(hop.ttl, self.flow)
+            probe_generator.create_probe(next_hop.ttl, self.flow)
             for _ in range(self.probes_per_hop)
         ]
 
@@ -205,7 +158,10 @@ class SinglepathEngine(AbstractEngine):
         for req, resp in ans:
             address, rtt = probe_generator.parse_probe_response(req, resp)
             vertex = TracerouteVertex(address)
-            hop.add_or_update(vertex, self.flow, rtt)
+            next_hop.add_or_update(vertex, self.flow, rtt)
+
+        hop.first().flow_set.add(self.flow)
+        hop.connectTo(next_hop)
 
 
 class MultipathEngine(AbstractEngine):
@@ -222,7 +178,7 @@ class MultipathEngine(AbstractEngine):
         timeout: float,
         abort: int,
     ):
-        super().__init__(inter, timeout, abort, opt_single_vertex_hop)
+        super().__init__(inter, timeout, abort)
         assert confidence > 0 and confidence < 1
         self.confidence = confidence
         assert retry >= 0
@@ -230,8 +186,9 @@ class MultipathEngine(AbstractEngine):
         assert min_burst > 0 and min_burst < max_burst
         self.min_burst = min_burst
         self.max_burst = max_burst
+        self.opt_single_vertex_hop = opt_single_vertex_hop
 
-    def _send_probes_to_hop(
+    def __send_probes_to_hop(
         self, probe_generator: AbstractProbeGen, hop: TracerouteHop, flows: set[int]
     ):
         """Sends probes with a given ttl and flows.
@@ -291,7 +248,7 @@ class MultipathEngine(AbstractEngine):
                 max_probes = result
         return max_probes
 
-    def _generate_flows(self, hop: TracerouteHop) -> Generator[set[int], None, None]:
+    def __generate_flows(self, hop: TracerouteHop) -> Generator[set[int], None, None]:
         """Generates flow sets until an optimal stopping point is reached."""
 
         def generate():
@@ -309,3 +266,44 @@ class MultipathEngine(AbstractEngine):
         while (stop := self.__nprobes(hop)) > start:
             yield set(islice(flow_generator, stop - start))
             start = stop
+
+    def _probe_and_update(
+        self,
+        probe_generator: AbstractProbeGen,
+        hop: TracerouteHop,
+        next_hop: TracerouteHop,
+    ):
+        """Probes a pair of hops and connects their vertices to each other."""
+        for flows in self.__generate_flows(hop):
+            # Send probes to the next hop first.
+            # For the path A -> B -> C -> D this leads to the following probing pattern:
+            # "B -> A -> C -> B -> D -> C" instead of
+            # "A -> B -> B -> C -> C -> D".
+            # By avoiding to probe hops twice in a row the impact of rate limiting
+            # is reduced.
+            n_hops = len(next_hop)
+            self.__send_probes_to_hop(probe_generator, next_hop, flows)
+            if len(next_hop) == n_hops:
+                log.warning("No new vertices detected, breaking from send loop")
+                break
+
+            missing_flows = next_hop.flows - hop.flows
+            send_probes = lambda: self.__send_probes_to_hop(
+                probe_generator, hop, missing_flows
+            )
+
+            if missing_flows:
+                if len(hop) == 1:
+                    if hop.ttl == 0:
+                        log.debug("Root hop found -> Skipping send_probes")
+                        hop.first().flow_set.update(missing_flows)
+                    elif self.opt_single_vertex_hop:
+                        log.debug("Single vertex hop found -> Skipping send_probes")
+                        hop.first().shadow_flow_set.update(missing_flows)
+                    else:
+                        send_probes()
+                        hop.first().shadow_flow_set.update(missing_flows - hop.flows)
+                else:
+                    send_probes()
+
+            hop.connectTo(next_hop)

--- a/client/src/core/engine.py
+++ b/client/src/core/engine.py
@@ -236,7 +236,7 @@ class MultipathEngine(AbstractEngine):
     def __nprobes(self, hop: TracerouteHop) -> int:
         """Computes the number of flows needed for the next hop."""
         probes = lambda v: stopping_point(
-            max(1, len(v.successors)), self.confidence
+            max(1, len(v.successors)) + 1, self.confidence
         )
 
         total_flows = len(hop.flows)

--- a/client/src/core/merge.py
+++ b/client/src/core/merge.py
@@ -2,20 +2,18 @@ from .container import TracerouteVertex, BlackHoleVertex
 from ipaddress import IPv4Network, IPv4Address
 from itertools import groupby, combinations, pairwise, product, chain
 from pprint import pprint
-from functools import reduce
+from functools import reduce, cache
+from collections import namedtuple
 import operator
 
 
 def group_subnets(vertices, prefix_len):
     vertices = (v for v in vertices if not isinstance(v, BlackHoleVertex))
     return {
-        subnet: {
-            v for v in vertices
-            if IPv4Address(v.address) in subnet.hosts()
-        }
+        subnet: {v for v in vertices if IPv4Address(v.address) in subnet.hosts()}
         for subnet, vertices in groupby(
             sorted(vertices, key=lambda v: IPv4Address(v.address)),
-            key=lambda v: IPv4Network(f"{v.address}/{prefix_len}", strict=False)
+            key=lambda v: IPv4Network(f"{v.address}/{prefix_len}", strict=False),
         )
     }
 
@@ -26,66 +24,59 @@ def accuracy(vertices, trace):
 
     for a, b in combinations(vertices, r=2):
         if abs(trace.index(a) - trace.index(b)) > 1:
-            print(f"Accuracy of {a} and {b} not met")
-            print(trace)
             return False
     return True
 
+
+@cache
 def form_subnets(forward, reverse):
     all_vertices = set(forward.flatten()) | set(reverse.flatten())
     completeness = lambda net, vertices: len(vertices) / net.num_addresses
     subnets_to_vertices = {}
-    
+
     def _form_subnets(prefix_len=24):
         if prefix_len >= 32:
             return
 
         matches = group_subnets(all_vertices, prefix_len)
         for subnet, vertices in matches.items():
-            print(f"{subnet=} {vertices=}")
             if completeness(subnet, vertices) < 0.5:
-                print(f"Completeness not satisfied.")
+                print(f"{subnet=}: Completeness not satisfied.")
                 continue
             for trace in chain(forward.traces(), reverse.traces()):
                 shared_vertices = set(trace) & vertices
                 if not accuracy(shared_vertices, trace):
-                    print("Accuracy not satisfied.")
+                    print(f"{subnet=}: Accuracy not satisfied.")
                     break
             else:
                 subnets_to_vertices[subnet] = vertices
 
-        _form_subnets(prefix_len+1)
+        _form_subnets(prefix_len + 1)
 
     _form_subnets()
     return sorted(
-        subnets_to_vertices.items(),
-        key=lambda x: completeness(*x),
-        reverse=True
+        subnets_to_vertices.items(), key=lambda x: completeness(*x), reverse=True
     )
-          
+
 
 def no_loop(forward, reverse, aliases):
-    for trace in chain(forward.traces(), reverse.traces()):
-        for alias in aliases:
-            if aliases - {alias} in trace:
-                return False
+    for trace in map(set, chain(forward.traces(), reverse.traces())):
+        if len(trace & aliases) > 1:
+            return False
     return True
-        
+
+
 def add_alias(vertex_pair, graph_pair, aliases):
     vertex_a, vertex_b = vertex_pair
     forward, reverse = graph_pair
 
-    overlap = {vertex_a, vertex_b}
-    existing_sets = [ 
-        alias_set for alias_set in aliases
-        if alias_set & overlap
-    ]
+    if vertex_a == vertex_b:
+        print("Alias pair is equal.")
+        return
 
-    merged_aliases = reduce(
-        operator.or_,
-        existing_sets,
-        overlap
-    )
+    overlap = {vertex_a, vertex_b}
+    existing_sets = [alias_set for alias_set in aliases if alias_set & overlap]
+    merged_aliases = reduce(operator.or_, existing_sets, overlap)
 
     if not no_loop(forward, reverse, merged_aliases):
         print("No-loop condition not met.")
@@ -95,92 +86,118 @@ def add_alias(vertex_pair, graph_pair, aliases):
         aliases.remove(existing_set)
 
     aliases.append(merged_aliases)
-    print(f"{aliases=}")
+    print(f"Resolved {aliases=}")
 
 
-def apar(forward, reverse):
+def common_subnet(f_trace, r_trace, f_index, r_index, seen_subnets):
+    if f_index < 1 or r_index < 1:
+        return False
+    candidate_subnet = {f_trace[f_index - 1], r_trace[r_index - 1]}
+    return any(candidate_subnet.issubset(net) for net in seen_subnets)
+
+
+def shared_neighbor(f_trace, r_trace, f_index, r_index):
+    if f_index < 2 or r_index < 1:
+        return False
+    return f_trace[f_index - 2] == r_trace[r_index - 1]
+
+
+def resolved_alias(f_trace, r_trace, f_index, r_index, aliases):
+    if f_index < 2 or r_index < 1:
+        return False
+    candidate_aliases = {f_trace[f_index - 2], r_trace[r_index - 1]}
+    return any(candidate_aliases.issubset(alias_set) for alias_set in aliases)
+
+
+def resolve_aliases(forward, reverse, p2p, aliases=[]):
     forward_traces = list(forward.traces())
     reverse_traces = list(reverse.traces())
 
+    aliases = list(aliases)
     seen_subnets = {}
-    aliases = []
 
     for subnet, vertices in form_subnets(forward, reverse):
-        print(f"{subnet=}")
+        print(f"{subnet=} {vertices=}")
         for f_trace, r_trace in product(forward_traces, reverse_traces):
+            r_trace = list(reversed(r_trace))
+
             f_vertices = set(f_trace) & vertices
             r_vertices = set(r_trace) & vertices
-
-            if not (f_vertices and r_vertices):
-                continue
 
             for f_vertex, r_vertex in product(f_vertices, r_vertices):
                 f_index = f_trace.index(f_vertex)
                 r_index = r_trace.index(r_vertex)
 
-                candidates = f_trace[f_index-1], r_trace[r_index]
-                lhs = f_trace[f_index-2], r_trace[r_index+1]
-
-                print()
-                print()
-                print(f"{f_trace=}")
-                print(f"{r_trace=}")
-                print(f"Aligned on {f_trace[f_index], r_trace[r_index]}")
+                if f_index < 1:
+                    continue
+                candidates = f_trace[f_index - 1], r_trace[r_index]
                 print(f"{candidates=}")
-                print(f"{lhs=}")
 
-                shared_neighbor = lambda: lhs[0] == lhs[1]
-                resolved_alias = lambda: any(set(lhs) & alias_set for alias_set in aliases)
-                common_subnet = lambda: any({lhs[1], candidates[0]} & vertices for vertices in seen_subnets.values())
+                params = {
+                    "f_trace": f_trace,
+                    "r_trace": r_trace,
+                    "f_index": f_index,
+                    "r_index": r_index,
+                }
 
-                print(f"{shared_neighbor()=}")
-                print(f"{resolved_alias()=}")
-                print(f"{common_subnet()=}")
-                if shared_neighbor() or resolved_alias() or common_subnet():
+                if (
+                    (p2p and subnet.prefixlen >= 30)
+                    or common_subnet(**params, seen_subnets=seen_subnets.values())
+                    or resolved_alias(**params, aliases=aliases)
+                    or shared_neighbor(**params)
+                ):
                     add_alias(candidates, (forward, reverse), aliases)
 
-
             seen_subnets[subnet] = vertices
+    return aliases
 
-    for subnet, vertices in seen_subnets.items():
-        if subnet.prefixlen < 30:
-            continue
-        for f_trace, r_trace in product(forward_traces, reverse_traces):
-            f_vertices = set(f_trace) & vertices
-            r_vertices = set(r_trace) & vertices
 
-            if not (f_vertices and r_vertices):
-                continue
+def apar(forward, reverse):
+    aliases = resolve_aliases(forward, reverse, False)
+    aliases = resolve_aliases(forward, reverse, True, aliases)
 
-            for f_vertex, r_vertex in product(f_vertices, r_vertices):
-                f_index = f_trace.index(f_vertex)
-                r_index = r_trace.index(r_vertex)
+    print()
+    print(f"{aliases=}")
 
-                candidates = f_trace[f_index-1], r_trace[r_index]
-                add_alias(candidates, (forward, reverse), aliases)
-     
+    return aliases
 
 
 forward_trace = [
-    TracerouteVertex(addr) for addr in [
-        "18.7.21.1", "18.168.0.27", "192.5.89.89", "192.5.89.10",
-        "198.32.8.85", "192.32.8.65", "192.32.8.33", "206.223.141.69",
-        "206.223.131.74"
+    TracerouteVertex(addr)
+    for addr in [
+        "18.7.21.1",
+        "18.168.0.27",
+        "192.5.89.89",
+        "192.5.89.10",
+        "198.32.8.85",
+        "192.32.8.65",
+        "192.32.8.33",
+        "206.223.141.69",
+        "206.223.131.74",
     ]
 ]
 
 reverse_trace = [
-    TracerouteVertex(addr) for addr in [
-        "18.7.21.7", "18.168.0.25", "192.5.89.90", "192.5.89.9",
-        "192.32.8.84", "192.32.8.66", "192.32.8.34", "206.223.141.70",
-        "206.223.141.73", "129.110.5.1", "129.110.95.1"
+    TracerouteVertex(addr)
+    for addr in [
+        "18.7.21.7",
+        "18.168.0.25",
+        "192.5.89.90",
+        "192.5.89.9",
+        "192.32.8.84",
+        "192.32.8.66",
+        "192.32.8.34",
+        "206.223.141.70",
+        "206.223.141.73",
+        "129.110.5.1",
+        "129.110.95.1",
     ]
 ]
 
-for a,b in pairwise(forward_trace):
+for a, b in pairwise(forward_trace):
     a.add_successor(b)
 
-for a,b in pairwise(reversed(reverse_trace)):
+for a, b in pairwise(reversed(reverse_trace)):
     a.add_successor(b)
 
 apar(forward_trace[0], reverse_trace[-1])

--- a/client/src/core/merge.py
+++ b/client/src/core/merge.py
@@ -2,139 +2,164 @@ from .container import TracerouteVertex, BlackHoleVertex
 from ipaddress import IPv4Network, IPv4Address
 from itertools import groupby, combinations, pairwise, product, chain
 from pprint import pprint
-from functools import reduce, cache
+from functools import reduce
 import operator
 
 
-class Apar:
-    def __init__(self, forward, reverse):
-        self.aliases = []
-        self.all_vertices = set(forward.flatten()) | set(reverse.flatten())
-        self.forward = forward
-        self.reverse = reverse
-
-    def group_subnets(self, vertices, prefix_len):
-        return {
-            k: list(v) for k,v in groupby(
-                vertices,
-                lambda v: IPv4Network(f"{v.address}/{prefix_len}", strict=False)
-            )
+def group_subnets(vertices, prefix_len):
+    vertices = (v for v in vertices if not isinstance(v, BlackHoleVertex))
+    return {
+        subnet: {
+            v for v in vertices
+            if IPv4Address(v.address) in subnet.hosts()
         }
-
-    @cache
-    def completeness(self, subnet):
-        return sum(
-            1 for addr in map(lambda v: IPv4Address(v.address), self.all_vertices)
-            if addr in subnet.hosts()
-        ) / sum(1 for _ in subnet.hosts())
-
-    def accuracy(self, vertices, trace):
-        for a, b in combinations(vertices, r=2):
-            if abs(trace.index(a) - trace.index(b)) > 1:
-                print(f"Accuracy of {a} and {b} not met")
-                print(trace)
-                return False
-        return True
-
-    def form_subnets(self, trace: list[TracerouteVertex]):
-        subnets = [ set() for _ in range(len(trace)) ]
-        
-        def _form_subnets(prefix_len=24):
-            if prefix_len >= 32:
-                return
-
-            matches = self.group_subnets(trace, prefix_len)
-
-            for subnet, vertices in matches.items():
-                for vertex in vertices:
-                    if IPv4Address(vertex.address) not in subnet.hosts():
-                        vertices.remove(vertex)
-
-                if not (vertices and self.accuracy(vertices, trace)):
-                    continue
-                if self.completeness(subnet) < 0.5:
-                    continue
-
-                for vertex in vertices:
-                    subnets[trace.index(vertex)].add(subnet)
-
-            _form_subnets(prefix_len+1)
-
-        _form_subnets()
-        return subnets
-
-    def no_loop(self, aliases):
-        for trace in chain(self.forward.traces(), self.reverse.traces()):
-            for alias in aliases:
-                if aliases - {alias} in trace:
-                    return False
-        return True
-            
-    def add_alias(self, vertex_a, vertex_b):
-        overlap = {vertex_a, vertex_b}
-        existing_sets = [ 
-            alias_set for alias_set in self.aliases
-            if alias_set & overlap
-        ]
-
-        aliases = reduce(
-            operator.or_,
-            (alias_set for alias_set in self.aliases if alias_set & overlap),
-            overlap
+        for subnet, vertices in groupby(
+            sorted(vertices, key=lambda v: IPv4Address(v.address)),
+            key=lambda v: IPv4Network(f"{v.address}/{prefix_len}", strict=False)
         )
+    }
 
-        if not self.no_loop(aliases):
-            print("No-loop condition not met.")
+
+def accuracy(vertices, trace):
+    if len(vertices) < 2:
+        return True
+
+    for a, b in combinations(vertices, r=2):
+        if abs(trace.index(a) - trace.index(b)) > 1:
+            print(f"Accuracy of {a} and {b} not met")
+            print(trace)
+            return False
+    return True
+
+def form_subnets(forward, reverse):
+    all_vertices = set(forward.flatten()) | set(reverse.flatten())
+    completeness = lambda net, vertices: len(vertices) / net.num_addresses
+    subnets_to_vertices = {}
+    
+    def _form_subnets(prefix_len=24):
+        if prefix_len >= 32:
             return
 
-        for existing_set in existing_sets:
-            self.aliases.remove(existing_set)
+        matches = group_subnets(all_vertices, prefix_len)
+        for subnet, vertices in matches.items():
+            print(f"{subnet=} {vertices=}")
+            if completeness(subnet, vertices) < 0.5:
+                print(f"Completeness not satisfied.")
+                continue
+            for trace in chain(forward.traces(), reverse.traces()):
+                shared_vertices = set(trace) & vertices
+                if not accuracy(shared_vertices, trace):
+                    print("Accuracy not satisfied.")
+                    break
+            else:
+                subnets_to_vertices[subnet] = vertices
 
-        self.aliases.append(aliases)
-        print(self.aliases)
+        _form_subnets(prefix_len+1)
+
+    _form_subnets()
+    return sorted(
+        subnets_to_vertices.items(),
+        key=lambda x: completeness(*x),
+        reverse=True
+    )
+          
+
+def no_loop(forward, reverse, aliases):
+    for trace in chain(forward.traces(), reverse.traces()):
+        for alias in aliases:
+            if aliases - {alias} in trace:
+                return False
+    return True
+        
+def add_alias(vertex_pair, graph_pair, aliases):
+    vertex_a, vertex_b = vertex_pair
+    forward, reverse = graph_pair
+
+    overlap = {vertex_a, vertex_b}
+    existing_sets = [ 
+        alias_set for alias_set in aliases
+        if alias_set & overlap
+    ]
+
+    merged_aliases = reduce(
+        operator.or_,
+        existing_sets,
+        overlap
+    )
+
+    if not no_loop(forward, reverse, merged_aliases):
+        print("No-loop condition not met.")
+        return
+
+    for existing_set in existing_sets:
+        aliases.remove(existing_set)
+
+    aliases.append(merged_aliases)
+    print(f"{aliases=}")
 
 
+def apar(forward, reverse):
+    forward_traces = list(forward.traces())
+    reverse_traces = list(reverse.traces())
 
-    def run(self):
-        forward_traces = self.forward.traces()
-        reverse_traces = self.reverse.traces()
-        for f, r in product(forward_traces, reverse_traces):
-            f_net_vertices = self.form_subnets(f)
-            r_net_vertices = self.form_subnets(r)
+    seen_subnets = {}
+    aliases = []
 
-            common_subnets = reduce(operator.or_, f_net_vertices) & reduce(operator.or_, r_net_vertices)
+    for subnet, vertices in form_subnets(forward, reverse):
+        print(f"{subnet=}")
+        for f_trace, r_trace in product(forward_traces, reverse_traces):
+            f_vertices = set(f_trace) & vertices
+            r_vertices = set(r_trace) & vertices
 
-            for subnet in reversed(sorted(common_subnets, key=self.completeness)):
-                f_indices = [ i for i,nets in enumerate(f_net_vertices) if subnet in nets ]
-                r_indices = [ i for i,nets in enumerate(r_net_vertices) if subnet in nets ]
+            if not (f_vertices and r_vertices):
+                continue
 
-                for f_index, r_index in product(f_indices, r_indices):
-                    candidates = f[f_index], r[r_index-1] 
-                    
-                    shared_subnets = lambda i,j: f_net_vertices[i] & r_net_vertices[j]
-                    if shared_subnets(f_index-1, r_index+1) and shared_subnets(f_index+1, r_index-1):
-                        print("Shared subnet condition.")
-                        self.add_alias(*candidates)
-                    elif f_net_vertices[f_index-1] == r_net_vertices[r_index+1]:
-                        print("Shared neighbor condition.")
-                        self.add_alias(*candidates)
-                    elif any({f[f_index-1],r[r_index+1]} & aliases for aliases in self.aliases):
-                        self.add_alias(*candidates)
-                print(subnet, f_indices, r_indices)
+            for f_vertex, r_vertex in product(f_vertices, r_vertices):
+                f_index = f_trace.index(f_vertex)
+                r_index = r_trace.index(r_vertex)
 
-            for subnet in reversed(sorted(common_subnets, key=self.completeness)):
-                if subnet.prefixlen < 30:
-                    continue
+                candidates = f_trace[f_index-1], r_trace[r_index]
+                lhs = f_trace[f_index-2], r_trace[r_index+1]
 
-                f_indices = [ i for i,nets in enumerate(f_net_vertices) if subnet in nets ]
-                r_indices = [ i for i,nets in enumerate(r_net_vertices) if subnet in nets ]
+                print()
+                print()
+                print(f"{f_trace=}")
+                print(f"{r_trace=}")
+                print(f"Aligned on {f_trace[f_index], r_trace[r_index]}")
+                print(f"{candidates=}")
+                print(f"{lhs=}")
 
-                for f_index, r_index in product(f_indices, r_indices):
-                    print("Second phase") 
-                    candidates = f[f_index], r[r_index-1] 
-                    self.add_alias(*candidates)
- 
-            #self.resolve(f, r, f_net_vertices, r_net_vertices)
+                shared_neighbor = lambda: lhs[0] == lhs[1]
+                resolved_alias = lambda: any(set(lhs) & alias_set for alias_set in aliases)
+                common_subnet = lambda: any({lhs[1], candidates[0]} & vertices for vertices in seen_subnets.values())
+
+                print(f"{shared_neighbor()=}")
+                print(f"{resolved_alias()=}")
+                print(f"{common_subnet()=}")
+                if shared_neighbor() or resolved_alias() or common_subnet():
+                    add_alias(candidates, (forward, reverse), aliases)
+
+
+            seen_subnets[subnet] = vertices
+
+    for subnet, vertices in seen_subnets.items():
+        if subnet.prefixlen < 30:
+            continue
+        for f_trace, r_trace in product(forward_traces, reverse_traces):
+            f_vertices = set(f_trace) & vertices
+            r_vertices = set(r_trace) & vertices
+
+            if not (f_vertices and r_vertices):
+                continue
+
+            for f_vertex, r_vertex in product(f_vertices, r_vertices):
+                f_index = f_trace.index(f_vertex)
+                r_index = r_trace.index(r_vertex)
+
+                candidates = f_trace[f_index-1], r_trace[r_index]
+                add_alias(candidates, (forward, reverse), aliases)
+     
+
 
 forward_trace = [
     TracerouteVertex(addr) for addr in [
@@ -146,7 +171,7 @@ forward_trace = [
 
 reverse_trace = [
     TracerouteVertex(addr) for addr in [
-        "18.7.21.84", "18.168.0.25", "192.5.89.90", "192.5.89.9",
+        "18.7.21.7", "18.168.0.25", "192.5.89.90", "192.5.89.9",
         "192.32.8.84", "192.32.8.66", "192.32.8.34", "206.223.141.70",
         "206.223.141.73", "129.110.5.1", "129.110.95.1"
     ]
@@ -158,5 +183,4 @@ for a,b in pairwise(forward_trace):
 for a,b in pairwise(reversed(reverse_trace)):
     a.add_successor(b)
 
-apar = Apar(forward_trace[0], reverse_trace[-1])
-apar.run()
+apar(forward_trace[0], reverse_trace[-1])

--- a/client/src/core/merge.py
+++ b/client/src/core/merge.py
@@ -70,9 +70,7 @@ def add_alias(vertex_pair, graph_pair, aliases):
     vertex_a, vertex_b = vertex_pair
     forward, reverse = graph_pair
 
-    if vertex_a == vertex_b:
-        print("Alias pair is equal.")
-        return
+    assert vertex_a != vertex_b
 
     overlap = {vertex_a, vertex_b}
     existing_sets = [alias_set for alias_set in aliases if alias_set & overlap]
@@ -118,7 +116,7 @@ def resolve_aliases(forward, reverse, p2p, aliases=[]):
 
     for subnet, vertices in form_subnets(forward, reverse):
         print(f"{subnet=} {vertices=}")
-        for f_trace, r_trace in product(forward_traces, reverse_traces):
+        for f_trace, r_trace in product(forward_traces + reverse_traces, repeat=2):
             r_trace = list(reversed(r_trace))
 
             f_vertices = set(f_trace) & vertices
@@ -130,8 +128,10 @@ def resolve_aliases(forward, reverse, p2p, aliases=[]):
 
                 if f_index < 1:
                     continue
+
                 candidates = f_trace[f_index - 1], r_trace[r_index]
-                print(f"{candidates=}")
+                if candidates[0] == candidates[1]:
+                    continue
 
                 params = {
                     "f_trace": f_trace,
@@ -158,6 +158,12 @@ def apar(forward, reverse):
 
     print()
     print(f"{aliases=}")
+
+    with open("traces.txt", "w") as f:
+        lines = []
+        for trace in chain(forward.traces(), reverse.traces()):
+            lines += ["#"] + [ v.address for v in trace ]
+        f.writelines("\n".join(lines))
 
     return aliases
 
@@ -194,6 +200,7 @@ reverse_trace = [
     ]
 ]
 
+"""
 for a, b in pairwise(forward_trace):
     a.add_successor(b)
 
@@ -201,3 +208,4 @@ for a, b in pairwise(reversed(reverse_trace)):
     a.add_successor(b)
 
 apar(forward_trace[0], reverse_trace[-1])
+"""

--- a/client/src/core/merge.py
+++ b/client/src/core/merge.py
@@ -1,0 +1,162 @@
+from .container import TracerouteVertex, BlackHoleVertex
+from ipaddress import IPv4Network, IPv4Address
+from itertools import groupby, combinations, pairwise, product, chain
+from pprint import pprint
+from functools import reduce, cache
+import operator
+
+
+class Apar:
+    def __init__(self, forward, reverse):
+        self.aliases = []
+        self.all_vertices = set(forward.flatten()) | set(reverse.flatten())
+        self.forward = forward
+        self.reverse = reverse
+
+    def group_subnets(self, vertices, prefix_len):
+        return {
+            k: list(v) for k,v in groupby(
+                vertices,
+                lambda v: IPv4Network(f"{v.address}/{prefix_len}", strict=False)
+            )
+        }
+
+    @cache
+    def completeness(self, subnet):
+        return sum(
+            1 for addr in map(lambda v: IPv4Address(v.address), self.all_vertices)
+            if addr in subnet.hosts()
+        ) / sum(1 for _ in subnet.hosts())
+
+    def accuracy(self, vertices, trace):
+        for a, b in combinations(vertices, r=2):
+            if abs(trace.index(a) - trace.index(b)) > 1:
+                print(f"Accuracy of {a} and {b} not met")
+                print(trace)
+                return False
+        return True
+
+    def form_subnets(self, trace: list[TracerouteVertex]):
+        subnets = [ set() for _ in range(len(trace)) ]
+        
+        def _form_subnets(prefix_len=24):
+            if prefix_len >= 32:
+                return
+
+            matches = self.group_subnets(trace, prefix_len)
+
+            for subnet, vertices in matches.items():
+                for vertex in vertices:
+                    if IPv4Address(vertex.address) not in subnet.hosts():
+                        vertices.remove(vertex)
+
+                if not (vertices and self.accuracy(vertices, trace)):
+                    continue
+                if self.completeness(subnet) < 0.5:
+                    continue
+
+                for vertex in vertices:
+                    subnets[trace.index(vertex)].add(subnet)
+
+            _form_subnets(prefix_len+1)
+
+        _form_subnets()
+        return subnets
+
+    def no_loop(self, aliases):
+        for trace in chain(self.forward.traces(), self.reverse.traces()):
+            for alias in aliases:
+                if aliases - {alias} in trace:
+                    return False
+        return True
+            
+    def add_alias(self, vertex_a, vertex_b):
+        overlap = {vertex_a, vertex_b}
+        existing_sets = [ 
+            alias_set for alias_set in self.aliases
+            if alias_set & overlap
+        ]
+
+        aliases = reduce(
+            operator.or_,
+            (alias_set for alias_set in self.aliases if alias_set & overlap),
+            overlap
+        )
+
+        if not self.no_loop(aliases):
+            print("No-loop condition not met.")
+            return
+
+        for existing_set in existing_sets:
+            self.aliases.remove(existing_set)
+
+        self.aliases.append(aliases)
+        print(self.aliases)
+
+
+
+    def run(self):
+        forward_traces = self.forward.traces()
+        reverse_traces = self.reverse.traces()
+        for f, r in product(forward_traces, reverse_traces):
+            f_net_vertices = self.form_subnets(f)
+            r_net_vertices = self.form_subnets(r)
+
+            common_subnets = reduce(operator.or_, f_net_vertices) & reduce(operator.or_, r_net_vertices)
+
+            for subnet in reversed(sorted(common_subnets, key=self.completeness)):
+                f_indices = [ i for i,nets in enumerate(f_net_vertices) if subnet in nets ]
+                r_indices = [ i for i,nets in enumerate(r_net_vertices) if subnet in nets ]
+
+                for f_index, r_index in product(f_indices, r_indices):
+                    candidates = f[f_index], r[r_index-1] 
+                    
+                    shared_subnets = lambda i,j: f_net_vertices[i] & r_net_vertices[j]
+                    if shared_subnets(f_index-1, r_index+1) and shared_subnets(f_index+1, r_index-1):
+                        print("Shared subnet condition.")
+                        self.add_alias(*candidates)
+                    elif f_net_vertices[f_index-1] == r_net_vertices[r_index+1]:
+                        print("Shared neighbor condition.")
+                        self.add_alias(*candidates)
+                    elif any({f[f_index-1],r[r_index+1]} & aliases for aliases in self.aliases):
+                        self.add_alias(*candidates)
+                print(subnet, f_indices, r_indices)
+
+            for subnet in reversed(sorted(common_subnets, key=self.completeness)):
+                if subnet.prefixlen < 30:
+                    continue
+
+                f_indices = [ i for i,nets in enumerate(f_net_vertices) if subnet in nets ]
+                r_indices = [ i for i,nets in enumerate(r_net_vertices) if subnet in nets ]
+
+                for f_index, r_index in product(f_indices, r_indices):
+                    print("Second phase") 
+                    candidates = f[f_index], r[r_index-1] 
+                    self.add_alias(*candidates)
+ 
+            #self.resolve(f, r, f_net_vertices, r_net_vertices)
+
+forward_trace = [
+    TracerouteVertex(addr) for addr in [
+        "18.7.21.1", "18.168.0.27", "192.5.89.89", "192.5.89.10",
+        "198.32.8.85", "192.32.8.65", "192.32.8.33", "206.223.141.69",
+        "206.223.131.74"
+    ]
+]
+
+reverse_trace = [
+    TracerouteVertex(addr) for addr in [
+        "18.7.21.84", "18.168.0.25", "192.5.89.90", "192.5.89.9",
+        "192.32.8.84", "192.32.8.66", "192.32.8.34", "206.223.141.70",
+        "206.223.141.73", "129.110.5.1", "129.110.95.1"
+    ]
+]
+
+for a,b in pairwise(forward_trace):
+    a.add_successor(b)
+
+for a,b in pairwise(reversed(reverse_trace)):
+    a.add_successor(b)
+
+apar = Apar(forward_trace[0], reverse_trace[-1])
+apar.run()

--- a/client/src/graph.py
+++ b/client/src/graph.py
@@ -19,13 +19,8 @@ from graphviz import Digraph
 from .core.container import TracerouteVertex
 
 
-def create_graph(
-    graph: Digraph, root: TracerouteVertex, hostnames: dict[str, str], merge: bool
-):
+def create_graph(graph: Digraph, root: TracerouteVertex, hostnames: dict[str, str]):
     """Create a digraph from the root vertex."""
-    if merge:
-        root.merge_vertices()
-
     nodes = list(root.flatten())
 
     for node in nodes:


### PR DESCRIPTION
## Two-way IP Alias Resolution
This pull request introduces the [APAR](https://ieeexplore.ieee.org/abstract/document/523375/citations?tabFilter=papers#citations) algorithm without an active probing component to analytically resolve possible IP alias pairs.
The algorithm is executed when specifying the `--resolve-aliases`  under the following conditions:
 * IPv4 is used
 * The probing direction is specified as two-way (both forward- and reverse)

The possible alias pairs found in the traces are written to a file in the format `{output}.aliases`,
where the placeholder `{output}` is determined by an argument passed to the client.

## Reducing the needed amount of NAT state on the client side
[Reverse traceroute probes use the ICMP identifier](https://datatracker.ietf.org/doc/html/draft-heiwin-intarea-reverse-traceroute#name-traceroute-request) field to encode a unique query identifier,
which is then used to match possible responses.
This field is also used by NAT middleboxes to [maintain NAT mappings for ICMP sessions](https://www.rfc-editor.org/rfc/rfc5508), which means that each probe leads to an individual mapping in the presence of such a middlebox.

To reduce the amount of state that must be maintained by a client-sided NAT,
the client now reuses request identifiers of previously answered requests.
This allows NAT boxes to use an already existing NAT mapping instead of creating a new one.

## Other Changes
* Changed the source port of classic traceroute probes to `33434`, which is [reserved for traceroute use](https://www.rfc-editor.org/rfc/rfc5508).
* Fixed an error, where less probes were sent than actually necessary.