### PR TITLE
Server

### DIFF
--- a/server/src/bpf/csum.c
+++ b/server/src/bpf/csum.c
@@ -21,10 +21,10 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 #include <linux/types.h>
 #include <bpf/bpf_endian.h>
 
-INTERNAL __sum16 csum(void *cursor, __u16 len, __be32 seed)
+INTERNAL __sum16 csum(const void *cursor, __u16 len, __be32 seed)
 {
     __be32 sum = seed;
-    __be16 *pos = cursor;
+    const __be16 *pos = cursor;
 
     while (len > 1) {
         sum += *(pos++);
@@ -41,7 +41,7 @@ INTERNAL __sum16 csum(void *cursor, __u16 len, __be32 seed)
     return (__sum16)~sum;
 }
 
-INTERNAL __be32 pseudo_header(iphdr_t *ip, __u16 probe_len, __u8 protocol)
+INTERNAL __be32 pseudo_header(const iphdr_t *ip, __u16 probe_len, __u8 protocol)
 {
     __be32 pseudo_hdr = bpf_htons(probe_len);
 

--- a/server/src/bpf/csum.h
+++ b/server/src/bpf/csum.h
@@ -25,7 +25,7 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 #include <linux/types.h>
 
 // Computes the checksum. See RFC1071 for details.
-INTERNAL __sum16 csum(void *cursor, __u16 len, __be32 seed);
-INTERNAL __be32 pseudo_header(iphdr_t *ip, __u16 probe_len, __u8 protocol);
+INTERNAL __sum16 csum(const void *cursor, __u16 len, __be32 seed);
+INTERNAL __be32 pseudo_header(const iphdr_t *ip, __u16 probe_len, __u8 protocol);
 
 #endif

--- a/server/src/bpf/csum.h
+++ b/server/src/bpf/csum.h
@@ -26,6 +26,7 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 
 // Computes the checksum. See RFC1071 for details.
 INTERNAL __sum16 csum(const void *cursor, __u16 len, __be32 seed);
-INTERNAL __be32 pseudo_header(const iphdr_t *ip, __u16 probe_len, __u8 protocol);
+INTERNAL __be32 pseudo_header(const iphdr_t *ip, __u16 probe_len,
+                              __u8 protocol);
 
 #endif

--- a/server/src/bpf/cursor.c
+++ b/server/src/bpf/cursor.c
@@ -20,12 +20,12 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 #include "cursor.h"
 #include <linux/bpf.h>
 
-INTERNAL long cursor_start(struct cursor *cursor)
+INTERNAL long cursor_start(const struct cursor *cursor)
 {
     return cursor->skb->data;
 }
 
-INTERNAL long cursor_end(struct cursor *cursor)
+INTERNAL long cursor_end(const struct cursor *cursor)
 {
     return cursor->skb->data_end;
 }
@@ -41,7 +41,7 @@ INTERNAL void cursor_init(struct cursor *cursor, struct __sk_buff *skb)
     cursor_reset(cursor);
 }
 
-INTERNAL void cursor_clone(struct cursor *original, struct cursor *clone)
+INTERNAL void cursor_clone(const struct cursor *original, struct cursor *clone)
 {
     *clone = *original;
 }

--- a/server/src/bpf/cursor.h
+++ b/server/src/bpf/cursor.h
@@ -28,11 +28,11 @@ struct cursor {
     void *pos;
 };
 
-INTERNAL long cursor_start(struct cursor *cursor);
-INTERNAL long cursor_end(struct cursor *cursor);
+INTERNAL long cursor_start(const struct cursor *cursor);
+INTERNAL long cursor_end(const struct cursor *cursor);
 INTERNAL void cursor_reset(struct cursor *cursor);
 INTERNAL void cursor_init(struct cursor *cursor, struct __sk_buff *skb);
-INTERNAL void cursor_clone(struct cursor *original, struct cursor *clone);
+INTERNAL void cursor_clone(const struct cursor *original, struct cursor *clone);
 
 #define PARSE(cursor, hdr)                                                     \
     ({                                                                         \

--- a/server/src/bpf/logging.c
+++ b/server/src/bpf/logging.c
@@ -29,7 +29,7 @@ struct {
     __uint(max_entries, 128 * 1024);
 } log_buf SEC(".maps");
 
-INTERNAL void log_message(enum message_type type, struct session_key *key)
+INTERNAL void log_message(enum message_type type, const struct session_key *key)
 {
     struct message *msg =
         bpf_ringbuf_reserve(&log_buf, sizeof(struct message), 0);

--- a/server/src/bpf/logging.h
+++ b/server/src/bpf/logging.h
@@ -25,6 +25,7 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 
 struct session_key;
 
-INTERNAL void log_message(enum message_type type, const struct session_key *key);
+INTERNAL void log_message(enum message_type type,
+                          const struct session_key *key);
 
 #endif

--- a/server/src/bpf/logging.h
+++ b/server/src/bpf/logging.h
@@ -25,6 +25,6 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 
 struct session_key;
 
-INTERNAL void log_message(enum message_type type, struct session_key *key);
+INTERNAL void log_message(enum message_type type, const struct session_key *key);
 
 #endif

--- a/server/src/bpf/probe.c
+++ b/server/src/bpf/probe.c
@@ -42,7 +42,7 @@ static int probe_match_icmp(struct cursor *cursor, __u8 is_request)
 
     if (PARSE(cursor, &icmp) < 0)
         return -1;
-    if (icmp->un.echo.id != SOURCE_PORT)
+    if (icmp->un.echo.sequence != ICMP_PROBE_SEQ)
         return -1;
 
     if (is_request) {
@@ -53,7 +53,7 @@ static int probe_match_icmp(struct cursor *cursor, __u8 is_request)
             return -1;
     }
 
-    return icmp->un.echo.sequence;
+    return icmp->un.echo.id;
 }
 
 /*
@@ -135,8 +135,8 @@ static probe_error probe_set_icmp(struct cursor *cursor, struct probe *probe,
     icmp->type = G_ICMP_ECHO_REQUEST;
     icmp->code = 0;
     icmp->checksum = probe->flow ? probe->flow : bpf_htons(0xbeaf);
-    icmp->un.echo.sequence = probe->identifier;
-    icmp->un.echo.id = SOURCE_PORT;
+    icmp->un.echo.id = probe->identifier;
+    icmp->un.echo.sequence = ICMP_PROBE_SEQ;
 
 #if defined(TRACEROUTE_V4)
     __be32 seed = 0;

--- a/server/src/bpf/probe.h
+++ b/server/src/bpf/probe.h
@@ -28,6 +28,7 @@ struct cursor;
 struct ethhdr;
 
 #define SOURCE_PORT bpf_htons(1021)
+#define ICMP_PROBE_SEQ 0xffff
 
 struct probe {
     __be16 flow;

--- a/server/src/bpf/session.c
+++ b/server/src/bpf/session.c
@@ -24,6 +24,9 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 #include <time.h>
 #include <bpf/bpf_helpers.h>
 
+// This variable may be overwritten by the program loader.
+// We declare it as volatile so the compiler won´t optimize it away,
+// e.g. inline the constant value into instructions.
 volatile const __u64 TIMEOUT_NS = DEFAULT_TIMEOUT_NS;
 
 // The internally used state consists of the usual state and a timer.
@@ -42,7 +45,7 @@ struct {
     __type(value, struct __session_state);
 } map_sessions SEC(".maps");
 
-static int session_timeout_callback(void *map, struct session_key *key,
+static int session_timeout_callback(void *map, const struct session_key *key,
                                     struct __session_state *state)
 {
     log_message(SESSION_TIMEOUT, key);
@@ -50,18 +53,18 @@ static int session_timeout_callback(void *map, struct session_key *key,
     return 0;
 }
 
-static struct __session_state *__session_find(struct session_key *key)
+static struct __session_state *__session_find(const struct session_key *key)
 {
     return bpf_map_lookup_elem(&map_sessions, key);
 }
 
-INTERNAL int session_delete(struct session_key *session)
+INTERNAL int session_delete(const struct session_key *session)
 {
     log_message(SESSION_DELETED, session);
     return bpf_map_delete_elem(&map_sessions, session);
 }
 
-INTERNAL struct session_state *session_find(struct session_key *key)
+INTERNAL struct session_state *session_find(const struct session_key *key)
 {
     struct __session_state *__state = __session_find(key);
 
@@ -70,8 +73,8 @@ INTERNAL struct session_state *session_find(struct session_key *key)
     return &__state->state;
 }
 
-INTERNAL int session_add(struct session_key *session,
-                         struct session_state *state)
+INTERNAL int session_add(const struct session_key *session,
+                         const struct session_state *state)
 {
     struct __session_state __state = {.state = *state, .padding = 0},
                            *state_ptr;

--- a/server/src/bpf/session.h
+++ b/server/src/bpf/session.h
@@ -34,9 +34,9 @@ struct session_state {
     __u64 timestamp_ns;
 };
 
-INTERNAL int session_delete(struct session_key *session);
-INTERNAL struct session_state *session_find(struct session_key *key);
-INTERNAL int session_add(struct session_key *session,
-                         struct session_state *state);
+INTERNAL int session_delete(const struct session_key *session);
+INTERNAL struct session_state *session_find(const struct session_key *key);
+INTERNAL int session_add(const struct session_key *session,
+                         const struct session_state *state);
 
 #endif

--- a/server/src/bpf/traceroute.c
+++ b/server/src/bpf/traceroute.c
@@ -192,10 +192,10 @@ static int handle(struct cursor *cursor)
         goto drop;
     return bpf_redirect(cursor->skb->ifindex, 0);
 
-// Jump here if packet has not been changed.
+// Jump here to allow the packet to proceed.
 pass:
     return TC_ACT_OK;
-// Jump here if packet has been changed.
+// Jump here to drop the packet.
 drop:
     return TC_ACT_SHOT;
 }

--- a/server/src/bpf/traceroute.c
+++ b/server/src/bpf/traceroute.c
@@ -153,21 +153,8 @@ static int handle(struct cursor *cursor)
     session.identifier = ret;
 
     state = session_find(&session);
-    if (!state) {
-        // ICMP responses are identified by the ID field,
-        // which may be used by outgoing ping packets as well.
-        // Thus, when receiving an ICMP packet that does not belong
-        // to reverse traceroute, it is passed up to userspace.
-        if (proto == G_PROTO_ICMP)
-            goto pass;
-        // TCP and UDP probes employ a specific source port,
-        // which will be reserved for reverse traceroute.
-        // As no other programs should use that port,
-        // we can drop all possible responses with no
-        // associated sessions.
-        else
-            goto drop;
-    }
+    if (!state)
+        goto drop;
 
     log_message(SESSION_PROBE_ANSWERED, &session);
     session_delete(&session);

--- a/server/src/messages.h
+++ b/server/src/messages.h
@@ -25,6 +25,7 @@ Augsburg-Traceroute. If not, see <https://www.gnu.org/licenses/>.
 #include <sys/socket.h>
 
 enum message_type {
+    SESSION_EXISTS,
     SESSION_CREATED,
     SESSION_DELETED,
     SESSION_TIMEOUT,

--- a/server/src/traceroute.c
+++ b/server/src/traceroute.c
@@ -157,25 +157,27 @@ static int log_message(void *ctx, void *data, size_t size)
 
     printf("[%*s, %5u] | ", ADDRSTRLEN, address, msg->data.probe_id);
     switch (msg->type) {
+    case SESSION_EXISTS:
+        printf("session exists.\n");
+        break;
     case SESSION_CREATED:
-        printf("session created.");
+        printf("session created.\n");
         break;
     case SESSION_DELETED:
-        printf("session deleted.");
+        printf("session deleted.\n");
         break;
     case SESSION_TIMEOUT:
-        printf("session timed out.");
+        printf("session timed out.\n");
         break;
     case SESSION_BUFFER_FULL:
-        printf("session buffer full.");
+        printf("session buffer full.\n");
         break;
     case SESSION_PROBE_ANSWERED:
-        printf("probe answer received.");
+        printf("probe answer received.\n");
         break;
     }
-    printf("\n");
+    
     fflush(stdout);
-
     return 0;
 }
 

--- a/server/src/traceroute.c
+++ b/server/src/traceroute.c
@@ -100,7 +100,7 @@ help:
     return -1;
 }
 
-static struct traceroute *traceroute_init(struct args *args)
+static struct traceroute *traceroute_init(const struct args *args)
 {
     struct rlimit mem_limit = {
         .rlim_cur = RLIM_INFINITY,
@@ -149,7 +149,7 @@ static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 
 static int log_message(void *ctx, void *data, size_t size)
 {
-    struct message *msg = data;
+    const struct message *msg = data;
 
     char address[ADDRSTRLEN];
     if (!inet_ntop(ADDR_FAMILY, &msg->data.address, address, sizeof(address)))
@@ -232,16 +232,16 @@ int main(int argc, char **argv)
     while (!exiting) {
         ret = ring_buffer__poll(log_buf, 100);
         if (ret == -EINTR) {
-            ret = 0;
             break;
         } else if (ret < 0) {
             fprintf(stderr, "Failed to poll the logging buffer.\n");
-            break;
+            goto free;
         }
     }
-    ring_buffer__free(log_buf);
 
     ret = EXIT_SUCCESS;
+free:
+    ring_buffer__free(log_buf);
 detach:
     opts.flags = opts.prog_fd = opts.prog_id = 0;
     bpf_tc_detach(&hook, &opts);


### PR DESCRIPTION
## Introducing Probe Randomization
Until now, the probes payload consisted of a 4-byte payload
which was computed by simple addition/subtraction to balance
out the checksum.
As payload computation was fully predictable with the operands
set by the client (and extracted by the server from the tr-requests),
the client had the ability to create a potentially malicious payload
that could be delivered to targets via IP spoofing.

Now the payload size is increased to 8-bytes, 6 of which are pseudo-randomly
generated. The last 2 bytes are used to balance out the checksum.
By introducing randomness into the computation, a malicious user no
longer has the ability to take control over the payload.

## Updated ICMP Probe Encoding
Until now, the ICMP identifier of the probe contained the constant probe ID,
which was used to check if the response may be an answer to a probe.
This has the drawback that when ping/traceroute are run on the server
machine, the ICMP identifier could overlap, leading to ping/traceroutes
responses being dropped by reverse traceroute or worse, invalid measurements.

Now the constant probe identifier is encoded into the ICMP sequence,
setting it to the highest possible value `0xffff`.
The requests query identifier is encoded into the probe's ICMP identifier.
This has the following advantage:

As classic traceroute uses its process ID (or an incremental value) to encode it inside the
ICMP identifier of generated probes and sequentially increments the
ICMP sequence field to match individual probes with responses,
the likelihood of clashes with a reverse traceroute server is
minimal: That is because we chose the highest possible value for the
probe identifier to be encoded into the ICMP sequence field. Classic
traceroute/ping will terminate before they reach such a high
sequence, and even if they do, this will lead to a single response
being dropped by the interference of reverse traceroute.

Paris-Traceroute on the other hand increments the ICMP identifier
and keeps the sequence at 0. There should be no clashes with
this tool either.

## Dropping Traceroute Responses with no active Session
All possible reverse traceroute responses are now dropped when no corresponding session can be found by the server.
As both UDP and TCP probes are identified by the source port `1021`, a port number reserved for experimental use,
traffic should not be disrupted (unless of course other software relies on the use of this port number).

With the updated probe encoding ICMP probes use the sequence `0xffff`.
Possible responses that reflect this value are therefore dropped as well.